### PR TITLE
Only call cleanup callback if it exists

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -133,5 +133,5 @@ exports.cleanup = function (callback) {
     phantomProcess = null;
   }
 
-  callback();
+  callback && callback();
 };

--- a/lib/main.js
+++ b/lib/main.js
@@ -133,5 +133,7 @@ exports.cleanup = function (callback) {
     phantomProcess = null;
   }
 
-  callback && callback();
+  if (callback) {
+    callback();
+  }
 };


### PR DESCRIPTION
When you just want to cleanup and don't need a message or anything else.. Otherwise it crashes.
